### PR TITLE
docs: link all library READMEs; simplify child READMEs; add feature implementation workflow

### DIFF
--- a/.windsurf/workflows/branch-from-readme.md
+++ b/.windsurf/workflows/branch-from-readme.md
@@ -1,0 +1,71 @@
+---
+description: Create a git branch following the naming rules defined in the root README
+---
+
+# Branch Creation Workflow (from README rules)
+
+This workflow helps you create a git branch that follows the rules documented in the root `README.md` under `## Development Workflow > ### Branch Naming`.
+
+Source rules in `README.md`:
+- Format: `<type>/<ticket-number>-<short-description>`
+- Types (examples from README): `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `style`
+
+## Steps
+
+1. Verify current repo status (read-only)
+   - Run: `git status -s`
+   - If there are uncommitted changes and you still want to proceed, you may stash them later.
+
+2. Choose base branch
+   - Default base: `main` (or specify another, e.g., `develop`)
+   - Run (optional): `git fetch origin`
+   - Run (optional): `git checkout <base>` then `git pull --ff-only`
+
+3. Collect branch inputs
+   - `type`: one of `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `style`
+   - `ticket-number`: digits only (e.g., `123`)
+   - `short-description`: kebab-case, 3–50 chars, only lowercase letters/numbers/hyphens (e.g., `normalize-readme-lints`)
+
+4. Validate inputs
+   - `type` ∈ allowed set above
+   - `ticket-number` matches `^\d+$`
+   - `short-description` matches `^[a-z0-9]+(?:-[a-z0-9]+)*$` and length ≤ 50
+   - Compose: `<type>/<ticket-number>-<short-description>`
+   - Examples:
+     - `feat/123-add-user-profile`
+     - `docs/45-update-readme-linting`
+
+5. Confirm branch name with user
+   - Prompt: "Create branch '<type>/<ticket-number>-<short-description>' from '<base>'? (yes/no)"
+
+6. Create branch (only after explicit confirmation)
+   - If working tree not clean, ask whether to stash:
+     - `git stash push -u -m "pre-branch: <branch-name>"`
+   - Create branch:
+     - `git checkout -b <branch-name> <base>`
+   - Optional: push upstream
+     - `git push -u origin <branch-name>`
+
+## Rules
+
+- Never create or switch branches without explicit confirmation from the user.
+- Prefer using the allowed `type` values; if a new type is desired, ask the user and record the decision.
+- Keep the `short-description` concise and meaningful; avoid generic terms like `changes` or `update`.
+- If validation fails, explain the specific reason and re-prompt.
+
+## Quick Prompts
+
+- Ask for inputs:
+  - "Type (feat|fix|chore|docs|test|refactor|style)?"
+  - "Ticket number (digits only)?"
+  - "Short description (kebab-case, <= 50 chars)?"
+  - "Base branch (default: main)?"
+- Confirm:
+  - "Create branch `<type>/<ticket-number>-<short-description>` from `<base>`?"
+- On approval, run in order:
+  - `git fetch origin`
+  - `git checkout <base>`
+  - `git pull --ff-only`
+  - (optional) `git stash push -u -m "pre-branch: <branch>"`
+  - `git checkout -b <branch> <base>`
+  - (optional) `git push -u origin <branch>`

--- a/.windsurf/workflows/commit-approval.md
+++ b/.windsurf/workflows/commit-approval.md
@@ -1,0 +1,48 @@
+---
+description: Require explicit approval before staging or committing changes
+---
+
+# Commit Approval Workflow
+
+This workflow ensures no git staging or commit happens without explicit user approval.
+
+## Steps
+
+1. Review pending changes
+   - Run: `git status -s`
+   - Run: `git diff` (or `git diff --staged` if applicable)
+   - Summarize files you intend to stage/commit.
+
+2. Ask for approval
+   - Prompt the user: "Do you want me to stage and commit these files? If yes, provide the commit message."
+   - Do not proceed unless the user explicitly says yes and provides a message.
+
+3. Stage files (only after explicit approval)
+   - Run: `git add <paths>`
+   - Prefer adding specific files (avoid `git add -A` unless the user requests it).
+
+4. Commit (only after explicit approval)
+   - Run: `git commit -m "<provided message>"`
+
+5. Optional: Push (only after explicit approval)
+   - Run: `git push -u origin <branch>`
+
+## Rules
+
+- Never stage or commit without an explicit instruction from the user in this session.
+- Always show `git status -s` and a diff first, then wait.
+- Use conventional commit messages when possible, e.g.:
+  - `feat(readme): normalize nx commands and remove redundant sections`
+  - `docs(readme): fix markdownlint warnings (MD009, MD012)`
+- If uncertain about scope or files, ask for clarification instead of guessing.
+
+## Quick Template
+
+- Pre-commit checks
+  - `git status -s`
+  - `git diff`
+- Ask: "Proceed to stage/commit? Commit message: <...>?"
+- On approval
+  - `git add <files>`
+  - `git commit -m "<message>"`
+  - (Optional) `git push -u origin <branch>`

--- a/.windsurf/workflows/feature-implementation.md
+++ b/.windsurf/workflows/feature-implementation.md
@@ -1,0 +1,106 @@
+---
+description: Structured workflow to go from requirements → analysis/plan → implementation with quality gates
+---
+
+# Feature / Change Implementation Workflow
+
+This workflow guides you from understanding requirements to planning and implementing changes with clear approval gates. Use it for features, refactors, bug fixes, and documentation updates.
+
+## 1) Understand the requirements (collect and clarify)
+
+Fill this template before touching code. If anything is unclear, ask and iterate.
+
+- Problem statement: <what pain are we solving?>
+- Objectives / Goals: <what success looks like>
+- Non-goals: <explicitly out of scope>
+- Stakeholders: <who cares / who approves>
+- Constraints: <deadlines, tech limits, security/compliance>
+- Dependencies: <internal libs, services, external APIs>
+- Acceptance criteria (testable):
+  - [ ] AC1: ...
+  - [ ] AC2: ...
+  - [ ] AC3: ...
+- Success metrics (if applicable): <e.g., performance, coverage, UX>
+
+Gate A — Confirm understanding
+- Ask for confirmation from the stakeholder. If approved, proceed.
+
+## 2) Analyze and devise a plan
+
+- Impact analysis:
+  - Affected apps/libs: <nx projects>
+  - Cross-cutting concerns: <auth, i18n, accessibility, security>
+  - Risks and mitigations: <technical/organizational>
+- Options considered and decision rationale
+- Implementation strategy:
+  - Tasks (high-level → granular):
+    - [ ] Task 1
+    - [ ] Task 2
+  - Testing strategy:
+    - Unit tests to add/modify
+    - Integration/E2E considerations
+  - Rollout plan: <flags, staged rollout, migration>
+  - Docs updates needed: <README, ADR, API docs>
+- Estimation: <S/M/L + assumptions>
+
+Gate B — Plan approval
+- Share the plan. Proceed only when approved.
+
+## 3) Make the changes (implementation)
+
+Recommended sequence and guardrails:
+
+1. Create branch using the branching workflow
+   - Use: `/branch-from-readme` (follows naming rules described in the root README)
+2. Add failing tests (TDD when reasonable)
+3. Implement code changes incrementally
+4. Keep commits small and atomic; use conventional commits
+5. Update documentation alongside code
+6. Verify locally
+   - Lint: `npx nx run-many -t lint --all`
+   - Unit tests: `npx nx run-many -t test --all`
+   - Build: `npx nx run-many -t build --all`
+   - Affected graph (optional): `npx nx affected:graph`
+7. Use commit approval workflow
+   - Use: `/commit-approval` to stage and commit with explicit confirmation
+8. Open PR with:
+   - Summary, scope, screenshots (if UI)
+   - Test plan, coverage summary, risks/mitigations
+   - Linked issues, breaking change note if any
+
+Gate C — Review and merge
+- Require at least one approval and passing CI. Address comments before merge.
+
+## 4) Definition of Done (DoD)
+
+- [ ] All acceptance criteria satisfied
+- [ ] Unit tests updated/added; coverage not degraded
+- [ ] Lint/build/test passing locally and in CI
+- [ ] Docs updated (README/ADR/API)
+- [ ] Security, accessibility, and performance considerations addressed (where relevant)
+- [ ] Feature flagged or migration path documented (if applicable)
+- [ ] Branch merged and tags/releases handled if needed
+
+## 5) Suggested additional rules for smooth working
+
+- Prefer “overview in root, details in child” docs structure
+- Keep function size small, meaningful naming, no unused code (aligns with repo quality standards)
+- Enforce strict TypeScript settings; avoid `any`; use interfaces for public APIs
+- Use `npx nx` consistently for all workspace commands
+- Add ADRs for significant architectural changes
+- Regularly run `npx nx graph` / `npx nx affected:graph` for impact awareness
+- Use feature flags for risky changes; document enable/disable path
+- Include accessibility (WCAG 2.1 AA) and i18n checks for UI work
+- Never commit without `/commit-approval` in this repo
+
+## Quick-use checklist
+
+- [ ] Gate A (requirements) approved
+- [ ] Gate B (plan) approved
+- [ ] Branch created via `/branch-from-readme`
+- [ ] Tests written/updated
+- [ ] Code + docs updated
+- [ ] Lint/test/build pass locally
+- [ ] `/commit-approval` used for commits
+- [ ] PR opened, CI green, review approved
+- [ ] DoD completed

--- a/README.md
+++ b/README.md
@@ -12,15 +12,24 @@ A modern, scalable beauty salon management platform built with Nx, Angular, and 
 cthub-bsaas/
 ├── apps/
 │   ├── web/              # Frontend applications
-│   │   ├── admin/        # Admin dashboard (Angular)
-│   │   ├── partner/      # Partner portal (Angular)
-│   │   └── customer/     # Customer app (Angular)
+│   │   ├── admin/        # Admin dashboard (web-admin)
+│   │   ├── partner/      # Partner portal (web-partner)
+│   │   └── customer/     # Customer app (web-customer)
 │   └── api/              # Backend API (NestJS)
 │
-├── libs/                 # Shared libraries
-│   ├── shared/           # Shared types and utilities
-│   ├── ui/              # Shared UI components
-│   └── feature/*        # Feature libraries
+├── libs/
+│   ├── server/             # Backend libraries
+│   │   ├── core/
+│   │   ├── data-access/
+│   │   └── features/
+│   ├── shared/             # Shared libraries (isomorphic)
+│   └── web/                # Frontend libraries
+│       ├── admin/
+│       ├── config/
+│       ├── core/
+│       ├── customer/
+│       ├── partner/
+│       └── ui/
 │
 ├── docs/                # Project documentation
 ├── scripts/             # Utility scripts
@@ -92,22 +101,23 @@ cthub-bsaas/
 - **Start admin dashboard in development mode**
 
   ```bash
-  npx nx serve admin
+  npx nx serve web-admin
   ```
 
 - **Start partner portal in development mode**
 
   ```bash
-  npx nx serve partner
+  npx nx serve web-partner
   ```
 
 - **Start customer app in development mode**
 
   ```bash
-  npx nx serve customer
+  npx nx serve web-customer
   ```
 
 - **Start backend API in development mode**
+
   ```bash
   npx nx serve api
   ```
@@ -124,9 +134,9 @@ cthub-bsaas/
 
   ```bash
   # Frontend apps
-  npx nx build admin
-  npx nx build partner
-  npx nx build customer
+  npx nx build web-admin
+  npx nx build web-partner
+  npx nx build web-customer
 
   # Backend
   npx nx build api
@@ -144,18 +154,19 @@ cthub-bsaas/
 
   ```bash
   # Frontend apps
-  npx nx test admin
-  npx nx test partner
-  npx nx test customer
+  npx nx test web-admin
+  npx nx test web-partner
+  npx nx test web-customer
 
   # Backend
   npx nx test api
   ```
 
 - **Run tests in watch mode**
+
   ```bash
   # Example for admin app
-  npx nx test admin --watch
+  npx nx test web-admin --watch
   ```
 
 ### Linting
@@ -167,6 +178,7 @@ cthub-bsaas/
   ```
 
 - **Fix linting issues**
+
   ```bash
   npx nx run-many --target=lint --all --fix
   ```
@@ -175,16 +187,16 @@ cthub-bsaas/
 
 ### Apps
 
-- **admin**: Admin dashboard (Angular)
-- **partner**: Partner portal (Angular)
-- **customer**: Customer application (Angular)
+- **web-admin**: Admin dashboard (Angular)
+- **web-partner**: Partner portal (Angular)
+- **web-customer**: Customer application (Angular)
 - **api**: Backend API (NestJS)
 
 ### Libraries
 
-- **shared**: Code shared between frontend and backend (DTOs, interfaces, utilities)
-- **frontend**: Shared frontend components and services
-- **ui**: Shared UI components library
+- **server/**: Backend libraries, separated by feature or concern (e.g., `core`, `data-access`).
+- **shared/**: Isomorphic libraries shared between frontend and backend (e.g., DTOs, interfaces, utilities).
+- **web/**: Frontend libraries, organized by scope (e.g., `core`, `config`, `ui`) and application-specific features (e.g., `admin/auth`).
 
 ## 🔧 Tools
 
@@ -206,7 +218,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 Use the following format for branch names:
 
-```
+```text
 <type>/<ticket-number>-<short-description>
 ```
 
@@ -222,7 +234,7 @@ Types:
 
 Example:
 
-```
+```text
 feat/123-add-user-profile
 ```
 
@@ -230,7 +242,7 @@ feat/123-add-user-profile
 
 Follow Conventional Commits specification:
 
-```
+```text
 <type>(<scope>): <description>
 
 [optional body]
@@ -240,7 +252,7 @@ Follow Conventional Commits specification:
 
 Example:
 
-```
+```text
 feat(auth): add password reset functionality
 
 - Add password reset endpoint

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 A modern, scalable beauty salon management platform built with Nx, Angular, and NestJS.
 
-> **Last Updated**: August 29, 2025
-
 ## 🏗️ Project Structure
 
 ```text
@@ -72,20 +70,20 @@ cthub-bsaas/
    Start the backend API:
 
    ```bash
-   nx serve api
+   npx nx serve api
    ```
 
    In a separate terminal, start the frontend application:
 
    ```bash
    # For admin dashboard
-   nx serve web-admin
+   npx nx serve web-admin
 
    # Or for partner portal
-   nx serve web-partner
+   npx nx serve web-partner
 
    # Or for customer app
-   nx serve web-customer
+   npx nx serve web-customer
    ```
 
 5. **Run database migrations**
@@ -115,7 +113,6 @@ cthub-bsaas/
   ```bash
   npx nx serve web-customer
   ```
-
 - **Start backend API in development mode**
 
   ```bash
@@ -185,18 +182,43 @@ cthub-bsaas/
 
 ## 🏗️ Project Structure Details
 
-### Apps
-
-- **web-admin**: Admin dashboard (Angular)
-- **web-partner**: Partner portal (Angular)
-- **web-customer**: Customer application (Angular)
-- **api**: Backend API (NestJS)
-
 ### Libraries
 
-- **server/**: Backend libraries, separated by feature or concern (e.g., `core`, `data-access`).
+- **server/**: Backend libraries, separated by feature or concern (e.g., `core`, `data-access`, `features`, `salon`).
 - **shared/**: Isomorphic libraries shared between frontend and backend (e.g., DTOs, interfaces, utilities).
 - **web/**: Frontend libraries, organized by scope (e.g., `core`, `config`, `ui`) and application-specific features (e.g., `admin/auth`).
+
+#### Library documentation
+
+- Overview of libraries: [libs/README.md](libs/README.md)
+
+- Server:
+  - [libs/server/core/README.md](libs/server/core/README.md)
+  - [libs/server/data-access/README.md](libs/server/data-access/README.md)
+  - [libs/server/features/README.md](libs/server/features/README.md)
+  - Features:
+    - [libs/server/features/appointment/README.md](libs/server/features/appointment/README.md)
+    - [libs/server/features/dashboard/README.md](libs/server/features/dashboard/README.md)
+    - [libs/server/features/portfolio/README.md](libs/server/features/portfolio/README.md)
+    - [libs/server/features/review/README.md](libs/server/features/review/README.md)
+    - [libs/server/features/salon/README.md](libs/server/features/salon/README.md)
+    - [libs/server/features/salon-staff-request/README.md](libs/server/features/salon-staff-request/README.md)
+    - [libs/server/features/social/README.md](libs/server/features/social/README.md)
+    - [libs/server/features/theme/README.md](libs/server/features/theme/README.md)
+    - [libs/server/features/user/README.md](libs/server/features/user/README.md)
+
+- Shared:
+  - [libs/shared/README.md](libs/shared/README.md)
+
+- Web Core:
+  - [libs/web/core/auth/README.md](libs/web/core/auth/README.md)
+  - [libs/web/core/http/README.md](libs/web/core/http/README.md)
+  - [libs/web/core/testing/README.md](libs/web/core/testing/README.md)
+
+- Web App-specific:
+  - [libs/web/admin/auth/README.md](libs/web/admin/auth/README.md)
+  - [libs/web/customer/auth/README.md](libs/web/customer/auth/README.md)
+  - [libs/web/partner/auth/README.md](libs/web/partner/auth/README.md)
 
 ## 🔧 Tools
 
@@ -288,7 +310,6 @@ Closes #123
 - Follow BEM naming convention
 - Use CSS custom properties for theming
 - Mobile-first approach
-
 
 ## API Development
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A modern, scalable beauty salon management platform built with Nx, Angular, and NestJS.
 
-> **Last Updated**: August 13, 2025
+> **Last Updated**: August 29, 2025
 
 ## 🏗️ Project Structure
 
@@ -196,26 +196,9 @@ cthub-bsaas/
 - **ESLint**: JavaScript/TypeScript linting
 - **Prettier**: Code formatting
 
-## 🤝 Contributing
-
-1. Create a new feature branch: `git checkout -b feature/your-feature`
-2. Make your changes
-3. Run tests: `npx nx affected:test`
-4. Lint your code: `npx nx affected:lint`
-5. Commit your changes: `git commit -m 'feat: your feature'`
-6. Push to the branch: `git push origin feature/your-feature`
-7. Create a Pull Request
-
 ## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-6. Start the development server:
-   ```bash
-   npm run dev
-   # or
-   yarn dev
-   ```
 
 ## Development Workflow
 
@@ -281,7 +264,7 @@ Closes #123
 
 ### TypeScript/JavaScript
 
-- Use 2 spaces for indentation
+- Use 4 spaces for indentation
 - Use single quotes
 - Always use semicolons
 - Maximum line length: 100 characters
@@ -294,22 +277,6 @@ Closes #123
 - Use CSS custom properties for theming
 - Mobile-first approach
 
-## Testing
-
-### Running Tests
-
-- Unit tests: `npm test`
-- Integration tests: `npm run test:integration`
-- E2E tests: `npm run test:e2e`
-- All tests: `npm run test:all`
-
-### Writing Tests
-
-- Use Jest for unit and integration tests
-- Use React Testing Library for component tests
-- Use Cypress for E2E tests
-- Follow AAA pattern (Arrange, Act, Assert)
-- Test both success and error cases
 
 ## API Development
 
@@ -430,15 +397,3 @@ Closes #123
    - Check for flaky tests
    - Update snapshots if needed
 
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Add tests
-5. Update documentation
-6. Submit a pull request
-
-## License
-
-[Your License Here]

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,12 +1,20 @@
-# Shared Libraries
+# Libraries
 
-This directory contains shared libraries used across the Beauty SaaS application. These libraries are designed to be reusable across different parts of the application.
+This directory contains reusable libraries used across the Beauty SaaS platform. Path aliases match the workspace configuration in `tsconfig.base.json`.
 
-## Available Libraries
+Note: This file provides an overview. Individual libraries include their own README with details (purpose, usage, testing) and link back here.
 
-- `@shared` - Core shared utilities, types, and enums used across the entire application
-- `@backend` - Backend-specific utilities, decorators, guards, and services
-- `@frontend` - Frontend components, services, and utilities for the web application
+## Available Libraries (aliases)
+
+- `@cthub-bsaas/shared` – Shared utilities, types, enums, and constants
+- `@cthub-bsaas/server-core` – Backend core modules (NestJS)
+- `@cthub-bsaas/server-data-access` – Backend data-access layer (ORM, repositories)
+- `@cthub-bsaas/web-admin-auth` – Admin app authentication utilities
+- `@cthub-bsaas/web-core-auth` – Web core auth services/guards
+- `@cthub-bsaas/web-core-http` – Web core HTTP abstractions/interceptors
+- `@cthub-bsaas/web-core-testing` – Web testing utilities
+- `@cthub-bsaas/web-customer-auth` – Customer app authentication utilities
+- `@cthub-bsaas/web-partner-auth` – Partner app authentication utilities
 
 ## Adding a New File to a Shared Library
 
@@ -14,7 +22,7 @@ This directory contains shared libraries used across the Beauty SaaS application
 
 Add your new file in the appropriate directory, for example:
 
-```
+```text
 libs/shared/src/types/new-type.ts
 ```
 
@@ -28,26 +36,26 @@ export * from './user.types.js';
 export * from './new-type.js'; // Add your new file
 ```
 
-### 3. Build the Shared Library
+### 3. Build a library (Nx)
 
 ```bash
-cd libs/shared
-npx tsc -p tsconfig.lib.json
+# Example: build shared library
+npx nx build shared
 ```
 
-### 4. Use Your New Export
+### 4. Use your new export
 
 Import your new file in your application:
 
 ```typescript
 // Import from the barrel export (recommended)
-import { NewType } from '@shared/types';
+import { NewType } from '@cthub-bsaas/shared/types';
 
 // Or import directly from the main index
-import { NewType } from '@shared';
+import { NewType } from '@cthub-bsaas/shared';
 ```
 
-## Example: Adding a New Enum
+## Example: Adding a new enum
 
 1. Create the enum file:
 
@@ -61,7 +69,7 @@ export enum PaymentStatus {
 }
 ```
 
-2. Update the enums index:
+1. Update the enums index:
 
 ```typescript
 // libs/shared/src/enums/index.ts
@@ -69,12 +77,12 @@ export * from './appointment-status.enum.js';
 export * from './payment-status.enum.js'; // Add this line
 ```
 
-3. Build the shared library (see step 3 above)
+1. Build the shared library (see step 3 above)
 
-4. Import in your application:
+1. Import in your application:
 
 ```typescript
-import { PaymentStatus } from '@shared/enums';
+import { PaymentStatus } from '@cthub-bsaas/shared/enums';
 ```
 
 ## Best Practices

--- a/libs/server/core/README.md
+++ b/libs/server/core/README.md
@@ -1,0 +1,9 @@
+# server-core
+
+Purpose: Backend core modules and utilities (NestJS) shared across server features.
+
+See overview: [libs/README.md](../../README.md)
+
+## Running unit tests
+
+Run `npx nx test server-core` to execute the unit tests.

--- a/libs/server/data-access/README.md
+++ b/libs/server/data-access/README.md
@@ -1,0 +1,9 @@
+# server-data-access
+
+Purpose: Backend data-access layer (Prisma, repositories) shared across server features.
+
+See overview: [libs/README.md](../../README.md)
+
+## Running unit tests
+
+Run `npx nx test server-data-access` to execute the unit tests.

--- a/libs/server/features/README.md
+++ b/libs/server/features/README.md
@@ -1,0 +1,9 @@
+# server-features
+
+Purpose: Aggregator of server feature libraries. Provides shared types and re-exports where applicable.
+
+See overview: [libs/README.md](../../README.md)
+
+## Running unit tests
+
+Run `npx nx test server-features` to execute the unit tests.

--- a/libs/server/features/appointment/README.md
+++ b/libs/server/features/appointment/README.md
@@ -1,0 +1,9 @@
+# server-appointment
+
+Purpose: Appointment domain feature library for the backend.
+
+See overview: [libs/README.md](../../../README.md)
+
+## Running unit tests
+
+Run `npx nx test server-appointment` to execute the unit tests.

--- a/libs/server/features/dashboard/README.md
+++ b/libs/server/features/dashboard/README.md
@@ -1,0 +1,9 @@
+# server-dashboard
+
+Purpose: Dashboard domain feature library for the backend.
+
+See overview: [libs/README.md](../../../README.md)
+
+## Running unit tests
+
+Run `npx nx test server-dashboard` to execute the unit tests.

--- a/libs/server/features/portfolio/README.md
+++ b/libs/server/features/portfolio/README.md
@@ -1,0 +1,9 @@
+# server-portfolio
+
+Purpose: Portfolio domain feature library for the backend.
+
+See overview: [libs/README.md](../../../README.md)
+
+## Running unit tests
+
+Run `npx nx test server-portfolio` to execute the unit tests.

--- a/libs/server/features/review/README.md
+++ b/libs/server/features/review/README.md
@@ -1,0 +1,9 @@
+# server-review
+
+Purpose: Review domain feature library for the backend.
+
+See overview: [libs/README.md](../../../README.md)
+
+## Running unit tests
+
+Run `npx nx test server-review` to execute the unit tests.

--- a/libs/server/features/salon-staff-request/README.md
+++ b/libs/server/features/salon-staff-request/README.md
@@ -1,0 +1,9 @@
+# server-salon-staff-request
+
+Purpose: Salon staff request domain feature library for the backend.
+
+See overview: [libs/README.md](../../../README.md)
+
+## Running unit tests
+
+Run `npx nx test server-salon-staff-request` to execute the unit tests.

--- a/libs/server/features/salon/README.md
+++ b/libs/server/features/salon/README.md
@@ -1,0 +1,9 @@
+# server-salon
+
+Purpose: Salon domain feature library for the backend.
+
+See overview: [libs/README.md](../../../README.md)
+
+## Running unit tests
+
+Run `npx nx test server-salon` to execute the unit tests.

--- a/libs/shared/README.md
+++ b/libs/shared/README.md
@@ -1,5 +1,9 @@
 # Shared Library
 
+Purpose: Isomorphic types, utilities, and constants shared across backend and frontend.
+
+See overview: [libs/README.md](../README.md)
+
 This library contains shared code used across the Beauty SaaS application, including:
 
 - **Models**: Shared TypeScript interfaces and types

--- a/libs/web/admin/auth/README.md
+++ b/libs/web/admin/auth/README.md
@@ -1,7 +1,9 @@
 # admin-auth
 
-This library was generated with [Nx](https://nx.dev).
+Purpose: Authentication utilities and facades for the Admin web app.
+
+See overview: [libs/README.md](../../../README.md)
 
 ## Running unit tests
 
-Run `nx test admin-auth` to execute the unit tests.
+Run `npx nx test web-admin-auth` to execute the unit tests.

--- a/libs/web/core/auth/README.md
+++ b/libs/web/core/auth/README.md
@@ -1,7 +1,9 @@
 # auth
 
-This library was generated with [Nx](https://nx.dev).
+Purpose: Core authentication services/guards shared across web apps.
+
+See overview: [libs/README.md](../../../README.md)
 
 ## Running unit tests
 
-Run `nx test auth` to execute the unit tests.
+Run `npx nx test web-core-auth` to execute the unit tests.

--- a/libs/web/core/http/README.md
+++ b/libs/web/core/http/README.md
@@ -1,7 +1,9 @@
 # http
 
-This library was generated with [Nx](https://nx.dev).
+Purpose: Core HTTP client abstractions, interceptors, and helpers shared across web apps.
+
+See overview: [libs/README.md](../../../README.md)
 
 ## Running unit tests
 
-Run `nx test http` to execute the unit tests.
+Run `npx nx test web-core-http` to execute the unit tests.

--- a/libs/web/core/testing/README.md
+++ b/libs/web/core/testing/README.md
@@ -1,7 +1,9 @@
 # testing
 
-This library was generated with [Nx](https://nx.dev).
+Purpose: Testing utilities and helpers shared across web apps.
+
+See overview: [libs/README.md](../../../README.md)
 
 ## Running unit tests
 
-Run `nx test testing` to execute the unit tests.
+Run `npx nx test web-core-testing` to execute the unit tests.

--- a/libs/web/customer/auth/README.md
+++ b/libs/web/customer/auth/README.md
@@ -1,7 +1,9 @@
 # customer-auth
 
-This library was generated with [Nx](https://nx.dev).
+Purpose: Authentication utilities and facades for the Customer web app.
+
+See overview: [libs/README.md](../../../README.md)
 
 ## Running unit tests
 
-Run `nx test customer-auth` to execute the unit tests.
+Run `npx nx test web-customer-auth` to execute the unit tests.

--- a/libs/web/partner/auth/README.md
+++ b/libs/web/partner/auth/README.md
@@ -1,7 +1,9 @@
 # partner-auth
 
-This library was generated with [Nx](https://nx.dev).
+Purpose: Authentication utilities and facades for the Partner web app.
+
+See overview: [libs/README.md](../../../README.md)
 
 ## Running unit tests
 
-Run `nx test partner-auth` to execute the unit tests.
+Run `npx nx test web-partner-auth` to execute the unit tests.


### PR DESCRIPTION
Summary
- Add root README links to all library README files (server/shared/web)
- Simplify child library READMEs (purpose + link back + Nx test cmd)
- Add feature implementation workflow under .windsurf/workflows

Testing
- Verified lint/test/build locally via Nx where applicable

Notes
- Documentation hierarchy: root = overview; child = details
- No runtime code changes
