### PR TITLE
fix(tsconfig): restrict jest types to test configs only

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -43,7 +43,7 @@
             "@cthub-bsaas/web-ui": ["libs/web/ui/src/index.ts", "dist/libs/web/ui/index.d.ts"],
             "@cthub-bsaas/web-ui/*": ["libs/web/ui/src/*", "dist/libs/web/ui/*"]
         },
-        "types": ["node", "jest"],
+        "types": ["node"],
         "experimentalDecorators": true,
         "sourceMap": true,
         "noUnusedParameters": true,


### PR DESCRIPTION
Remove jest from root tsconfig.base.json to avoid leaking test types into prod builds. Verified project-level tsconfig.spec.json include jest types. Skipped lint/test/build per instruction.