### PR TITLE
fix(tsconfig): stop root declaration emit leaking into apps

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -49,8 +49,6 @@
         "noUnusedParameters": true,
         "noUnusedLocals": true,
         "noImplicitReturns": true,
-        "declarationMap": true,
-        "declaration": true,
         "noImplicitAny": true,
         "resolveJsonModule": true
     },


### PR DESCRIPTION
Remove declaration/declarationMap from tsconfig.base.json so only libs emit .d.ts via their tsconfig.lib.json. Apps no longer emit declarations, improving build times.