### PR TITLE
fix(tests): replace deprecated moduleResolution node10 with node in spec tsconfigs

### DIFF
--- a/libs/web/admin/auth/tsconfig.spec.json
+++ b/libs/web/admin/auth/tsconfig.spec.json
@@ -5,7 +5,7 @@
     "module": "commonjs",
     "target": "es2016",
     "types": ["jest", "node"],
-    "moduleResolution": "node10"
+    "moduleResolution": "node"
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/libs/web/core/auth/tsconfig.spec.json
+++ b/libs/web/core/auth/tsconfig.spec.json
@@ -8,7 +8,7 @@
       "jest",
       "node"
     ],
-    "moduleResolution": "node10"
+    "moduleResolution": "node"
   },
   "files": [
     "src/test-setup.ts"

--- a/libs/web/core/http/tsconfig.spec.json
+++ b/libs/web/core/http/tsconfig.spec.json
@@ -5,7 +5,7 @@
     "module": "commonjs",
     "target": "es2016",
     "types": ["jest", "node"],
-    "moduleResolution": "node10"
+    "moduleResolution": "node"
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/libs/web/core/testing/tsconfig.spec.json
+++ b/libs/web/core/testing/tsconfig.spec.json
@@ -5,7 +5,7 @@
     "module": "commonjs",
     "target": "es2016",
     "types": ["jest", "node"],
-    "moduleResolution": "node10"
+    "moduleResolution": "node"
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/libs/web/customer/auth/tsconfig.spec.json
+++ b/libs/web/customer/auth/tsconfig.spec.json
@@ -5,7 +5,7 @@
     "module": "commonjs",
     "target": "es2016",
     "types": ["jest", "node"],
-    "moduleResolution": "node10"
+    "moduleResolution": "node"
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/libs/web/partner/auth/tsconfig.spec.json
+++ b/libs/web/partner/auth/tsconfig.spec.json
@@ -5,7 +5,7 @@
     "module": "commonjs",
     "target": "es2016",
     "types": ["jest", "node"],
-    "moduleResolution": "node10"
+    "moduleResolution": "node"
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/libs/web/ui/tsconfig.spec.json
+++ b/libs/web/ui/tsconfig.spec.json
@@ -8,7 +8,7 @@
       "jest",
       "node"
     ],
-    "moduleResolution": "node10"
+    "moduleResolution": "node"
   },
   "files": [
     "src/test-setup.ts"


### PR DESCRIPTION
Update Angular library tsconfig.spec.json files to use moduleResolution: 'node' for Jest instead of deprecated 'node10'. Keeps module: 'commonjs'. Affects: web/admin/auth, web/core/auth, web/core/http, web/core/testing, web/customer/auth, web/partner/auth, web/ui.