### PR TITLE
build(tsconfig): align libs/apps tsconfigs; test(server): use CJS in server Jest specs

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -4,14 +4,11 @@
     "outDir": "dist",
     "rootDir": "../../",
     "typeRoots": ["node_modules/@types", "../../node_modules/@types"],
-    "types": ["node", "express", "jest"],
+    "types": ["node", "express"],
     "composite": true,
     "incremental": true,
     "preserveSymlinks": true // Important for monorepo setups
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.spec.ts"
-  ],
+  "include": ["src/**/*.ts", "src/**/*.spec.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/apps/web/admin/tsconfig.app.json
+++ b/apps/web/admin/tsconfig.app.json
@@ -9,7 +9,9 @@
     "target": "ES2022",
     "types": ["node"],
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "useDefineForClassFields": true
   },
   "files": ["src/main.ts"],
   "include": ["src/**/*.ts", "src/**/*.d.ts"],

--- a/apps/web/admin/tsconfig.json
+++ b/apps/web/admin/tsconfig.json
@@ -1,29 +1,29 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "../../../dist/apps/web/admin",
-    "baseUrl": ".",
-    "paths": {
-      "@env/*": ["src/environments/*"],
-      "@app/*": ["src/app/*"],
-      "@shared/*": ["../../../libs/shared/src/*"],
-      "@cthub-bsaas/ui": ["../../../libs/ui/src/index.ts"],
-      "@cthub-bsaas/ui/*": ["../../../libs/ui/src/*"],
-      "@cthub-bsaas/web-admin/auth": ["../../../libs/web/admin/auth/src/index.ts"],
-      "@cthub-bsaas/shared": ["../../../libs/shared/src/index.ts"],
-      "@cthub-bsaas/shared/*": ["../../../libs/shared/src/*"],
-      "@cthub-bsaas/web-config": ["../../../libs/web/config/src/index.ts"],
-      "@cthub-bsaas/web-core/auth": ["../../../libs/web/core/auth/src/index.ts"],
-      "@cthub-bsaas/web-core/http": ["../../../libs/web/core/http/src/index.ts"],
-      "@cthub-bsaas/web-core/testing": ["../../../libs/web/core/testing/src/index.ts"]
+    "extends": "../../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/apps/web/admin",
+        "baseUrl": ".",
+        "paths": {
+            "@env/*": ["src/environments/*"],
+            "@app/*": ["src/app/*"],
+            "@shared/*": ["../../../libs/shared/src/*"],
+            "@cthub-bsaas/ui": ["../../../libs/ui/src/index.ts"],
+            "@cthub-bsaas/ui/*": ["../../../libs/ui/src/*"],
+            "@cthub-bsaas/web-admin/auth": ["../../../libs/web/admin/auth/src/index.ts"],
+            "@cthub-bsaas/shared": ["../../../libs/shared/src/index.ts"],
+            "@cthub-bsaas/shared/*": ["../../../libs/shared/src/*"],
+            "@cthub-bsaas/web-config": ["../../../libs/web/config/src/index.ts"],
+            "@cthub-bsaas/web-core/auth": ["../../../libs/web/core/auth/src/index.ts"],
+            "@cthub-bsaas/web-core/http": ["../../../libs/web/core/http/src/index.ts"],
+            "@cthub-bsaas/web-core/testing": ["../../../libs/web/core/testing/src/index.ts"]
+        },
+        "types": ["node"],
+        "esModuleInterop": true
     },
-    "types": ["node", "jest"],
-    "esModuleInterop": true
-  },
-  "angularCompilerOptions": {
-    "enableI18nLegacyMessageIdFormat": false,
-    "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
-  }
+    "angularCompilerOptions": {
+        "enableI18nLegacyMessageIdFormat": false,
+        "strictInjectionParameters": true,
+        "strictInputAccessModifiers": true,
+        "strictTemplates": true
+    }
 }

--- a/apps/web/admin/tsconfig.spec.json
+++ b/apps/web/admin/tsconfig.spec.json
@@ -20,7 +20,9 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "typeRoots": ["./node_modules/@types", "./src/types"],
-    "lib": ["es2022", "dom"]
+    "lib": ["es2022", "dom"],
+    "isolatedModules": true,
+    "useDefineForClassFields": true
   },
   "include": [
     "src/**/*.spec.ts",

--- a/apps/web/customer/tsconfig.app.json
+++ b/apps/web/customer/tsconfig.app.json
@@ -9,7 +9,9 @@
     "target": "ES2022",
     "types": ["node"],
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "useDefineForClassFields": true
   },
   "files": ["src/main.ts"],
   "include": ["src/**/*.ts", "src/**/*.d.ts"],

--- a/apps/web/customer/tsconfig.json
+++ b/apps/web/customer/tsconfig.json
@@ -1,27 +1,27 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "../../../dist/apps/web/customer",
-    "baseUrl": ".",
-    "paths": {
-      "@env/*": ["src/environments/*"],
-      "@app/*": ["src/app/*"],
-      "@shared/*": ["../../../libs/shared/src/*"],
-      "@cthub-bsaas/ui": ["../../../libs/ui/src/index.ts"],
-      "@cthub-bsaas/ui/*": ["../../../libs/ui/src/*"],
-      "@cthub-bsaas/web-customer/auth": ["../../../libs/web/customer/auth/src/index.ts"],
-      "@cthub-bsaas/web-config": ["../../../libs/web/config/src/index.ts"],
-      "@cthub-bsaas/web-core/auth": ["../../../libs/web/core/auth/src/index.ts"],
-      "@cthub-bsaas/web-core/http": ["../../../libs/web/core/http/src/index.ts"],
-      "@cthub-bsaas/web-core/testing": ["../../../libs/web/core/testing/src/index.ts"]
+    "extends": "../../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/apps/web/customer",
+        "baseUrl": ".",
+        "paths": {
+            "@env/*": ["src/environments/*"],
+            "@app/*": ["src/app/*"],
+            "@shared/*": ["../../../libs/shared/src/*"],
+            "@cthub-bsaas/ui": ["../../../libs/ui/src/index.ts"],
+            "@cthub-bsaas/ui/*": ["../../../libs/ui/src/*"],
+            "@cthub-bsaas/web-customer/auth": ["../../../libs/web/customer/auth/src/index.ts"],
+            "@cthub-bsaas/web-config": ["../../../libs/web/config/src/index.ts"],
+            "@cthub-bsaas/web-core/auth": ["../../../libs/web/core/auth/src/index.ts"],
+            "@cthub-bsaas/web-core/http": ["../../../libs/web/core/http/src/index.ts"],
+            "@cthub-bsaas/web-core/testing": ["../../../libs/web/core/testing/src/index.ts"]
+        },
+        "types": ["node"],
+        "esModuleInterop": true
     },
-    "types": ["node", "jest"],
-    "esModuleInterop": true
-  },
-  "angularCompilerOptions": {
-    "enableI18nLegacyMessageIdFormat": false,
-    "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
-  }
+    "angularCompilerOptions": {
+        "enableI18nLegacyMessageIdFormat": false,
+        "strictInjectionParameters": true,
+        "strictInputAccessModifiers": true,
+        "strictTemplates": true
+    }
 }

--- a/apps/web/customer/tsconfig.spec.json
+++ b/apps/web/customer/tsconfig.spec.json
@@ -20,7 +20,9 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "typeRoots": ["./node_modules/@types", "./src/types"],
-    "lib": ["es2022", "dom"]
+    "lib": ["es2022", "dom"],
+    "isolatedModules": true,
+    "useDefineForClassFields": true
   },
   "include": [
     "src/**/*.spec.ts",

--- a/apps/web/partner/tsconfig.app.json
+++ b/apps/web/partner/tsconfig.app.json
@@ -9,7 +9,9 @@
     "target": "ES2022",
     "types": ["node"],
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "useDefineForClassFields": true
   },
   "files": ["src/main.ts"],
   "include": ["src/**/*.ts", "src/**/*.d.ts"],

--- a/apps/web/partner/tsconfig.json
+++ b/apps/web/partner/tsconfig.json
@@ -1,29 +1,29 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "../../../dist/apps/web/partner",
-    "baseUrl": ".",
-    "paths": {
-      "@env/*": ["src/environments/*"],
-      "@app/*": ["src/app/*"],
-      "@shared/*": ["../../../libs/shared/src/*"],
-      "@cthub-bsaas/ui": ["../../../libs/ui/src/index.ts"],
-      "@cthub-bsaas/ui/*": ["../../../libs/ui/src/*"],
-      "@cthub-bsaas/web-partner/auth": ["../../../libs/web/partner/auth/src/index.ts"],
-      "@cthub-bsaas/shared": ["../../../libs/shared/src/index.ts"],
-      "@cthub-bsaas/shared/*": ["../../../libs/shared/src/*"],
-      "@cthub-bsaas/web-config": ["../../../libs/web/config/src/index.ts"],
-      "@cthub-bsaas/web-core/auth": ["../../../libs/web/core/auth/src/index.ts"],
-      "@cthub-bsaas/web-core/http": ["../../../libs/web/core/http/src/index.ts"],
-      "@cthub-bsaas/web-core/testing": ["../../../libs/web/core/testing/src/index.ts"]
+    "extends": "../../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/apps/web/partner",
+        "baseUrl": ".",
+        "paths": {
+            "@env/*": ["src/environments/*"],
+            "@app/*": ["src/app/*"],
+            "@shared/*": ["../../../libs/shared/src/*"],
+            "@cthub-bsaas/ui": ["../../../libs/ui/src/index.ts"],
+            "@cthub-bsaas/ui/*": ["../../../libs/ui/src/*"],
+            "@cthub-bsaas/web-partner/auth": ["../../../libs/web/partner/auth/src/index.ts"],
+            "@cthub-bsaas/shared": ["../../../libs/shared/src/index.ts"],
+            "@cthub-bsaas/shared/*": ["../../../libs/shared/src/*"],
+            "@cthub-bsaas/web-config": ["../../../libs/web/config/src/index.ts"],
+            "@cthub-bsaas/web-core/auth": ["../../../libs/web/core/auth/src/index.ts"],
+            "@cthub-bsaas/web-core/http": ["../../../libs/web/core/http/src/index.ts"],
+            "@cthub-bsaas/web-core/testing": ["../../../libs/web/core/testing/src/index.ts"]
+        },
+        "types": ["node"],
+        "esModuleInterop": true
     },
-    "types": ["node", "jest"],
-    "esModuleInterop": true
-  },
-  "angularCompilerOptions": {
-    "enableI18nLegacyMessageIdFormat": false,
-    "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
-  }
+    "angularCompilerOptions": {
+        "enableI18nLegacyMessageIdFormat": false,
+        "strictInjectionParameters": true,
+        "strictInputAccessModifiers": true,
+        "strictTemplates": true
+    }
 }

--- a/apps/web/partner/tsconfig.spec.json
+++ b/apps/web/partner/tsconfig.spec.json
@@ -20,7 +20,9 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "typeRoots": ["./node_modules/@types", "./src/types"],
-    "lib": ["es2022", "dom"]
+    "lib": ["es2022", "dom"],
+    "isolatedModules": true,
+    "useDefineForClassFields": true
   },
   "include": [
     "src/**/*.spec.ts",

--- a/libs/server/core/tsconfig.lib.json
+++ b/libs/server/core/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../tsconfig.base.json",
     "compilerOptions": {
+        "rootDir": "src",
         "types": ["node"],
         "isolatedModules": false,
         "experimentalDecorators": true,

--- a/libs/server/core/tsconfig.spec.json
+++ b/libs/server/core/tsconfig.spec.json
@@ -6,7 +6,9 @@
     "moduleResolution": "node",
     "types": ["jest", "node"],
     "esModuleInterop": true,
-    "target": "es2022"
+    "target": "es2022",
+    "isolatedModules": false,
+    "useDefineForClassFields": false
   },
   "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/core/tsconfig.spec.json
+++ b/libs/server/core/tsconfig.spec.json
@@ -1,14 +1,14 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "es2022",
-    "moduleResolution": "node",
-    "types": ["jest", "node"],
-    "esModuleInterop": true,
-    "target": "es2022",
-    "isolatedModules": false,
-    "useDefineForClassFields": false
-  },
-  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/out-tsc",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "types": ["jest", "node"],
+        "esModuleInterop": true,
+        "target": "es2022",
+        "isolatedModules": false,
+        "useDefineForClassFields": false
+    },
+    "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/data-access/tsconfig.lib.json
+++ b/libs/server/data-access/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../tsconfig.base.json",
     "compilerOptions": {
+        "rootDir": "src",
         "outDir": "../../../dist/libs/server/data-access",
         "declaration": true,
         "declarationMap": true,

--- a/libs/server/data-access/tsconfig.lib.json
+++ b/libs/server/data-access/tsconfig.lib.json
@@ -5,7 +5,7 @@
         "declaration": true,
         "declarationMap": true,
         "sourceMap": true,
-        "types": ["node", "jest"],
+        "types": ["node"],
         "composite": true,
         "isolatedModules": false,
         "experimentalDecorators": true,

--- a/libs/server/data-access/tsconfig.spec.json
+++ b/libs/server/data-access/tsconfig.spec.json
@@ -6,7 +6,9 @@
     "moduleResolution": "node",
     "types": ["jest", "node"],
     "esModuleInterop": true,
-    "target": "es2022"
+    "target": "es2022",
+    "isolatedModules": false,
+    "useDefineForClassFields": false
   },
   "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/data-access/tsconfig.spec.json
+++ b/libs/server/data-access/tsconfig.spec.json
@@ -1,14 +1,14 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "es2022",
-    "moduleResolution": "node",
-    "types": ["jest", "node"],
-    "esModuleInterop": true,
-    "target": "es2022",
-    "isolatedModules": false,
-    "useDefineForClassFields": false
-  },
-  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/out-tsc",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "types": ["jest", "node"],
+        "esModuleInterop": true,
+        "target": "es2022",
+        "isolatedModules": false,
+        "useDefineForClassFields": false
+    },
+    "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/features/appointment/tsconfig.lib.json
+++ b/libs/server/features/appointment/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "../../../../dist/out-tsc",
     "declaration": true,
     "declarationMap": true,

--- a/libs/server/features/appointment/tsconfig.spec.json
+++ b/libs/server/features/appointment/tsconfig.spec.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": false,
+    "useDefineForClassFields": false
   },
   "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts"]
 }

--- a/libs/server/features/dashboard/tsconfig.lib.json
+++ b/libs/server/features/dashboard/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "../../../../dist/out-tsc",
     "declaration": true,
     "declarationMap": true,

--- a/libs/server/features/dashboard/tsconfig.spec.json
+++ b/libs/server/features/dashboard/tsconfig.spec.json
@@ -6,7 +6,9 @@
     "moduleResolution": "node",
     "types": ["jest", "node"],
     "esModuleInterop": true,
-    "target": "es2022"
+    "target": "es2022",
+    "isolatedModules": false,
+    "useDefineForClassFields": false
   },
   "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/features/dashboard/tsconfig.spec.json
+++ b/libs/server/features/dashboard/tsconfig.spec.json
@@ -1,14 +1,14 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "es2022",
-    "moduleResolution": "node",
-    "types": ["jest", "node"],
-    "esModuleInterop": true,
-    "target": "es2022",
-    "isolatedModules": false,
-    "useDefineForClassFields": false
-  },
-  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/out-tsc",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "types": ["jest", "node"],
+        "esModuleInterop": true,
+        "target": "es2022",
+        "isolatedModules": false,
+        "useDefineForClassFields": false
+    },
+    "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/features/portfolio/tsconfig.lib.json
+++ b/libs/server/features/portfolio/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "../../../../dist/out-tsc",
     "declaration": true,
     "declarationMap": true,

--- a/libs/server/features/portfolio/tsconfig.spec.json
+++ b/libs/server/features/portfolio/tsconfig.spec.json
@@ -6,7 +6,9 @@
     "moduleResolution": "node",
     "types": ["jest", "node"],
     "esModuleInterop": true,
-    "target": "es2022"
+    "target": "es2022",
+    "isolatedModules": false,
+    "useDefineForClassFields": false
   },
   "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/features/portfolio/tsconfig.spec.json
+++ b/libs/server/features/portfolio/tsconfig.spec.json
@@ -1,14 +1,14 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "es2022",
-    "moduleResolution": "node",
-    "types": ["jest", "node"],
-    "esModuleInterop": true,
-    "target": "es2022",
-    "isolatedModules": false,
-    "useDefineForClassFields": false
-  },
-  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/out-tsc",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "types": ["jest", "node"],
+        "esModuleInterop": true,
+        "target": "es2022",
+        "isolatedModules": false,
+        "useDefineForClassFields": false
+    },
+    "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/features/review/tsconfig.lib.json
+++ b/libs/server/features/review/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "../../../../dist/out-tsc",
     "declaration": true,
     "declarationMap": true,

--- a/libs/server/features/salon-staff-request/tsconfig.lib.json
+++ b/libs/server/features/salon-staff-request/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "../../../../dist/out-tsc",
     "declaration": true,
     "declarationMap": true,

--- a/libs/server/features/salon-staff-request/tsconfig.spec.json
+++ b/libs/server/features/salon-staff-request/tsconfig.spec.json
@@ -6,7 +6,9 @@
     "moduleResolution": "node",
     "types": ["jest", "node"],
     "esModuleInterop": true,
-    "target": "es2022"
+    "target": "es2022",
+    "isolatedModules": false,
+    "useDefineForClassFields": false
   },
   "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/features/salon-staff-request/tsconfig.spec.json
+++ b/libs/server/features/salon-staff-request/tsconfig.spec.json
@@ -1,14 +1,14 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "es2022",
-    "moduleResolution": "node",
-    "types": ["jest", "node"],
-    "esModuleInterop": true,
-    "target": "es2022",
-    "isolatedModules": false,
-    "useDefineForClassFields": false
-  },
-  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/out-tsc",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "types": ["jest", "node"],
+        "esModuleInterop": true,
+        "target": "es2022",
+        "isolatedModules": false,
+        "useDefineForClassFields": false
+    },
+    "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/features/salon/tsconfig.lib.json
+++ b/libs/server/features/salon/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "../../../../dist/out-tsc",
     "declaration": true,
     "declarationMap": true,

--- a/libs/server/features/salon/tsconfig.spec.json
+++ b/libs/server/features/salon/tsconfig.spec.json
@@ -6,7 +6,9 @@
     "moduleResolution": "node",
     "types": ["jest", "node"],
     "esModuleInterop": true,
-    "target": "es2022"
+    "target": "es2022",
+    "isolatedModules": false,
+    "useDefineForClassFields": false
   },
   "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/features/salon/tsconfig.spec.json
+++ b/libs/server/features/salon/tsconfig.spec.json
@@ -1,14 +1,14 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "es2022",
-    "moduleResolution": "node",
-    "types": ["jest", "node"],
-    "esModuleInterop": true,
-    "target": "es2022",
-    "isolatedModules": false,
-    "useDefineForClassFields": false
-  },
-  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/out-tsc",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "types": ["jest", "node"],
+        "esModuleInterop": true,
+        "target": "es2022",
+        "isolatedModules": false,
+        "useDefineForClassFields": false
+    },
+    "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/features/social/tsconfig.lib.json
+++ b/libs/server/features/social/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "../../../../dist/out-tsc",
     "declaration": true,
     "declarationMap": true,

--- a/libs/server/features/social/tsconfig.spec.json
+++ b/libs/server/features/social/tsconfig.spec.json
@@ -6,7 +6,9 @@
     "moduleResolution": "node",
     "types": ["jest", "node"],
     "esModuleInterop": true,
-    "target": "es2022"
+    "target": "es2022",
+    "isolatedModules": false,
+    "useDefineForClassFields": false
   },
   "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/features/social/tsconfig.spec.json
+++ b/libs/server/features/social/tsconfig.spec.json
@@ -1,14 +1,14 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "es2022",
-    "moduleResolution": "node",
-    "types": ["jest", "node"],
-    "esModuleInterop": true,
-    "target": "es2022",
-    "isolatedModules": false,
-    "useDefineForClassFields": false
-  },
-  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/out-tsc",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "types": ["jest", "node"],
+        "esModuleInterop": true,
+        "target": "es2022",
+        "isolatedModules": false,
+        "useDefineForClassFields": false
+    },
+    "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/features/theme/tsconfig.lib.json
+++ b/libs/server/features/theme/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "../../../../dist/out-tsc",
     "declaration": true,
     "declarationMap": true,

--- a/libs/server/features/theme/tsconfig.spec.json
+++ b/libs/server/features/theme/tsconfig.spec.json
@@ -6,7 +6,9 @@
     "moduleResolution": "node",
     "types": ["jest", "node"],
     "esModuleInterop": true,
-    "target": "es2022"
+    "target": "es2022",
+    "isolatedModules": false,
+    "useDefineForClassFields": false
   },
   "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/features/theme/tsconfig.spec.json
+++ b/libs/server/features/theme/tsconfig.spec.json
@@ -1,14 +1,14 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "es2022",
-    "moduleResolution": "node",
-    "types": ["jest", "node"],
-    "esModuleInterop": true,
-    "target": "es2022",
-    "isolatedModules": false,
-    "useDefineForClassFields": false
-  },
-  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/out-tsc",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "types": ["jest", "node"],
+        "esModuleInterop": true,
+        "target": "es2022",
+        "isolatedModules": false,
+        "useDefineForClassFields": false
+    },
+    "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/features/tsconfig.lib.json
+++ b/libs/server/features/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../tsconfig.base.json",
     "compilerOptions": {
+        "rootDir": "src",
         "composite": true,
         "outDir": "../../../../dist/out-tsc",
         "declaration": true,

--- a/libs/server/features/tsconfig.lib.json
+++ b/libs/server/features/tsconfig.lib.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../../tsconfig.base.json",
+    "extends": "../../../tsconfig.base.json",
     "compilerOptions": {
         "composite": true,
         "outDir": "../../../../dist/out-tsc",

--- a/libs/server/features/user/tsconfig.lib.json
+++ b/libs/server/features/user/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "../../../../dist/out-tsc",
     "declaration": true,
     "declarationMap": true,

--- a/libs/server/features/user/tsconfig.spec.json
+++ b/libs/server/features/user/tsconfig.spec.json
@@ -6,7 +6,9 @@
     "moduleResolution": "node",
     "types": ["jest", "node"],
     "esModuleInterop": true,
-    "target": "es2022"
+    "target": "es2022",
+    "isolatedModules": false,
+    "useDefineForClassFields": false
   },
   "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/server/features/user/tsconfig.spec.json
+++ b/libs/server/features/user/tsconfig.spec.json
@@ -1,14 +1,14 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "es2022",
-    "moduleResolution": "node",
-    "types": ["jest", "node"],
-    "esModuleInterop": true,
-    "target": "es2022",
-    "isolatedModules": false,
-    "useDefineForClassFields": false
-  },
-  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/out-tsc",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "types": ["jest", "node"],
+        "esModuleInterop": true,
+        "target": "es2022",
+        "isolatedModules": false,
+        "useDefineForClassFields": false
+    },
+    "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts", "**/*.fixture.ts"]
 }

--- a/libs/shared/tsconfig.json
+++ b/libs/shared/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "files": [],
-  "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    }
-  ]
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "module": "preserve",
+        "moduleResolution": "bundler",
+        "skipLibCheck": true
+    },
+    "files": [],
+    "references": [{ "path": "./tsconfig.lib.json" }, { "path": "./tsconfig.spec.json" }]
 }

--- a/libs/shared/tsconfig.lib.json
+++ b/libs/shared/tsconfig.lib.json
@@ -1,12 +1,16 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "../../dist/libs/shared",
-    "declaration": true,
-    "declarationMap": true,
-    "composite": true,
-    "types": ["node", "jest"]
-  },
-  "include": ["src/**/*.ts"],
-  "exclude": ["**/*.spec.ts", "**/*.test.ts"]
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "../../dist/libs/shared",
+        "declaration": true,
+        "declarationMap": true,
+        "composite": true,
+        "rootDir": "src",
+        "isolatedModules": true,
+        "useDefineForClassFields": true,
+        "lib": ["ES2022"],
+        "types": ["node"]
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["**/*.spec.ts", "**/*.test.ts"]
 }

--- a/libs/shared/tsconfig.spec.json
+++ b/libs/shared/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "target": "ES2022",
+        "types": ["jest", "node"],
+
+        "isolatedModules": true,
+        "useDefineForClassFields": true
+    },
+    "include": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts", "src/**/*.d.ts"]
+}

--- a/libs/web/admin/auth/tsconfig.lib.json
+++ b/libs/web/admin/auth/tsconfig.lib.json
@@ -5,7 +5,9 @@
         "declaration": true,
         "declarationMap": true,
         "inlineSources": true,
-        "types": []
+        "types": [],
+        "isolatedModules": true,
+        "useDefineForClassFields": true
     },
     "angularCompilerOptions": { "compilationMode": "partial" },
     "exclude": ["src/test-setup.ts", "**/*.spec.ts", "jest.config.ts", "**/*.test.ts"],

--- a/libs/web/admin/auth/tsconfig.lib.json
+++ b/libs/web/admin/auth/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../../tsconfig.base.json",
     "compilerOptions": {
+        "rootDir": "src",
         "outDir": "../../../../dist/out-tsc/libs/web/admin/auth",
         "declaration": true,
         "declarationMap": true,

--- a/libs/web/admin/auth/tsconfig.spec.json
+++ b/libs/web/admin/auth/tsconfig.spec.json
@@ -5,7 +5,9 @@
     "module": "commonjs",
     "target": "es2016",
     "types": ["jest", "node"],
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "isolatedModules": true,
+    "useDefineForClassFields": true
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/libs/web/config/tsconfig.lib.json
+++ b/libs/web/config/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../tsconfig.base.json",
     "compilerOptions": {
+        "rootDir": "src",
         "outDir": "../../../dist/out-tsc/libs/web/config",
         "declaration": true,
         "declarationMap": true,

--- a/libs/web/core/auth/tsconfig.lib.json
+++ b/libs/web/core/auth/tsconfig.lib.json
@@ -5,7 +5,9 @@
         "declaration": true,
         "declarationMap": true,
         "inlineSources": true,
-        "types": []
+        "types": [],
+        "isolatedModules": true,
+        "useDefineForClassFields": true
     },
     "angularCompilerOptions": {
         "skipTemplateCodegen": true,

--- a/libs/web/core/auth/tsconfig.lib.json
+++ b/libs/web/core/auth/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../../tsconfig.base.json",
     "compilerOptions": {
+        "rootDir": "src",
         "outDir": "../../../../dist/out-tsc",
         "declaration": true,
         "declarationMap": true,

--- a/libs/web/core/auth/tsconfig.spec.json
+++ b/libs/web/core/auth/tsconfig.spec.json
@@ -8,7 +8,9 @@
       "jest",
       "node"
     ],
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "isolatedModules": true,
+    "useDefineForClassFields": true
   },
   "files": [
     "src/test-setup.ts"

--- a/libs/web/core/http/tsconfig.lib.json
+++ b/libs/web/core/http/tsconfig.lib.json
@@ -7,7 +7,9 @@
         "inlineSources": true,
         "types": [],
         "skipLibCheck": true,
-        "paths": {}
+        "paths": {},
+        "isolatedModules": true,
+        "useDefineForClassFields": true
     },
     "angularCompilerOptions": {
         "compilationMode": "partial",

--- a/libs/web/core/http/tsconfig.lib.json
+++ b/libs/web/core/http/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../../tsconfig.base.json",
     "compilerOptions": {
+        "rootDir": "src",
         "outDir": "../../../../dist/out-tsc/libs/web/core/http",
         "declaration": true,
         "declarationMap": true,

--- a/libs/web/core/http/tsconfig.spec.json
+++ b/libs/web/core/http/tsconfig.spec.json
@@ -5,7 +5,9 @@
     "module": "commonjs",
     "target": "es2016",
     "types": ["jest", "node"],
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "isolatedModules": true,
+    "useDefineForClassFields": true
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/libs/web/core/testing/tsconfig.lib.json
+++ b/libs/web/core/testing/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../../tsconfig.base.json",
     "compilerOptions": {
+        "rootDir": "src",
         "composite": true,
         "outDir": "../../../../dist/out-tsc/libs/web/core/testing",
         "declaration": true,

--- a/libs/web/core/testing/tsconfig.lib.json
+++ b/libs/web/core/testing/tsconfig.lib.json
@@ -6,7 +6,9 @@
         "declaration": true,
         "declarationMap": true,
         "inlineSources": true,
-        "types": []
+        "types": [],
+        "isolatedModules": true,
+        "useDefineForClassFields": true
     },
     "angularCompilerOptions": { "compilationMode": "partial" },
     "exclude": ["src/test-setup.ts", "**/*.spec.ts", "jest.config.ts", "**/*.test.ts"],

--- a/libs/web/core/testing/tsconfig.spec.json
+++ b/libs/web/core/testing/tsconfig.spec.json
@@ -5,7 +5,9 @@
     "module": "commonjs",
     "target": "es2016",
     "types": ["jest", "node"],
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "isolatedModules": true,
+    "useDefineForClassFields": true
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/libs/web/customer/auth/tsconfig.lib.json
+++ b/libs/web/customer/auth/tsconfig.lib.json
@@ -5,7 +5,9 @@
         "declaration": true,
         "declarationMap": true,
         "inlineSources": true,
-        "types": []
+        "types": [],
+        "isolatedModules": true,
+        "useDefineForClassFields": true
     },
     "angularCompilerOptions": {
         "skipTemplateCodegen": true,

--- a/libs/web/customer/auth/tsconfig.lib.json
+++ b/libs/web/customer/auth/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../../tsconfig.base.json",
     "compilerOptions": {
+        "rootDir": "src",
         "outDir": "../../../../dist/out-tsc",
         "declaration": true,
         "declarationMap": true,

--- a/libs/web/customer/auth/tsconfig.spec.json
+++ b/libs/web/customer/auth/tsconfig.spec.json
@@ -5,7 +5,9 @@
     "module": "commonjs",
     "target": "es2016",
     "types": ["jest", "node"],
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "isolatedModules": true,
+    "useDefineForClassFields": true
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/libs/web/partner/auth/tsconfig.lib.json
+++ b/libs/web/partner/auth/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../../tsconfig.base.json",
     "compilerOptions": {
+        "rootDir": "src",
         "outDir": "../../../../dist/out-tsc/libs/web/partner/auth",
         "declaration": true,
         "declarationMap": true,

--- a/libs/web/partner/auth/tsconfig.lib.json
+++ b/libs/web/partner/auth/tsconfig.lib.json
@@ -5,7 +5,9 @@
         "declaration": true,
         "declarationMap": true,
         "inlineSources": true,
-        "types": []
+        "types": [],
+        "isolatedModules": true,
+        "useDefineForClassFields": true
     },
     "angularCompilerOptions": { "compilationMode": "partial" },
     "exclude": ["src/test-setup.ts", "**/*.spec.ts", "jest.config.ts", "**/*.test.ts"],

--- a/libs/web/partner/auth/tsconfig.spec.json
+++ b/libs/web/partner/auth/tsconfig.spec.json
@@ -5,7 +5,9 @@
     "module": "commonjs",
     "target": "es2016",
     "types": ["jest", "node"],
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "isolatedModules": true,
+    "useDefineForClassFields": true
   },
   "files": ["src/test-setup.ts"],
   "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/libs/web/ui/tsconfig.lib.json
+++ b/libs/web/ui/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../tsconfig.base.json",
     "compilerOptions": {
+        "rootDir": "src",
         "outDir": "../../../dist/out-tsc/libs/web/ui",
         "declaration": true,
         "declarationMap": true,

--- a/libs/web/ui/tsconfig.lib.json
+++ b/libs/web/ui/tsconfig.lib.json
@@ -5,7 +5,9 @@
         "declaration": true,
         "declarationMap": true,
         "inlineSources": true,
-        "types": []
+        "types": [],
+        "isolatedModules": true,
+        "useDefineForClassFields": true
     },
     "angularCompilerOptions": {
         "compilationMode": "partial"

--- a/libs/web/ui/tsconfig.spec.json
+++ b/libs/web/ui/tsconfig.spec.json
@@ -8,7 +8,9 @@
       "jest",
       "node"
     ],
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "isolatedModules": true,
+    "useDefineForClassFields": true
   },
   "files": [
     "src/test-setup.ts"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,7 @@
         "forceConsistentCasingInFileNames": true,
         "target": "ES2022",
         "baseUrl": ".",
-        "useDefineForClassFields": true,
+        
         "importHelpers": true,
         "emitDecoratorMetadata": true,
         "module": "ES2022",


### PR DESCRIPTION
- Removed Jest types from app build configs:\n  - apps/api/tsconfig.json → types: ['node','express']\n  - apps/web/{admin,customer,partner}/tsconfig.json → types: ['node']\n- Added rootDir: 'src' to all lib tsconfig.lib.json that set outDir for sturdier composite/declaration emits.\n- Ensured server Jest spec tsconfigs use commonjs to avoid ESM friction.\n- Kept Jest types only in spec configs.\n\nOutcome: consistent, portable typings; cleaner builds; Jest isolated to tests.