### PR TITLE
chore(server): rename server feature projects to server-feature-* and update build/docs

### DIFF
--- a/libs/server/features/appointment/README.md
+++ b/libs/server/features/appointment/README.md
@@ -1,4 +1,4 @@
-# server-appointment
+# server-feature-appointment
 
 Purpose: Appointment domain feature library for the backend.
 
@@ -6,4 +6,4 @@ See overview: [libs/README.md](../../../README.md)
 
 ## Running unit tests
 
-Run `npx nx test server-appointment` to execute the unit tests.
+Run `npx nx test server-feature-appointment` to execute the unit tests.

--- a/libs/server/features/appointment/project.json
+++ b/libs/server/features/appointment/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "server-appointment",
+  "name": "server-feature-appointment",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "libs/server/features/appointment/src",

--- a/libs/server/features/dashboard/README.md
+++ b/libs/server/features/dashboard/README.md
@@ -1,4 +1,4 @@
-# server-dashboard
+# server-feature-dashboard
 
 Purpose: Dashboard domain feature library for the backend.
 
@@ -6,4 +6,4 @@ See overview: [libs/README.md](../../../README.md)
 
 ## Running unit tests
 
-Run `npx nx test server-dashboard` to execute the unit tests.
+Run `npx nx test server-feature-dashboard` to execute the unit tests.

--- a/libs/server/features/dashboard/project.json
+++ b/libs/server/features/dashboard/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "server-dashboard",
+  "name": "server-feature-dashboard",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "libs/server/features/dashboard/src",

--- a/libs/server/features/portfolio/README.md
+++ b/libs/server/features/portfolio/README.md
@@ -1,4 +1,4 @@
-# server-portfolio
+# server-feature-portfolio
 
 Purpose: Portfolio domain feature library for the backend.
 
@@ -6,4 +6,4 @@ See overview: [libs/README.md](../../../README.md)
 
 ## Running unit tests
 
-Run `npx nx test server-portfolio` to execute the unit tests.
+Run `npx nx test server-feature-portfolio` to execute the unit tests.

--- a/libs/server/features/portfolio/project.json
+++ b/libs/server/features/portfolio/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "server-portfolio",
+  "name": "server-feature-portfolio",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "libs/server/features/portfolio/src",

--- a/libs/server/features/review/README.md
+++ b/libs/server/features/review/README.md
@@ -1,4 +1,4 @@
-# server-review
+# server-feature-review
 
 Purpose: Review domain feature library for the backend.
 
@@ -6,4 +6,4 @@ See overview: [libs/README.md](../../../README.md)
 
 ## Running unit tests
 
-Run `npx nx test server-review` to execute the unit tests.
+Run `npx nx test server-feature-review` to execute the unit tests.

--- a/libs/server/features/review/project.json
+++ b/libs/server/features/review/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "server-review",
+  "name": "server-feature-review",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "libs/server/features/review/src",

--- a/libs/server/features/salon-staff-request/README.md
+++ b/libs/server/features/salon-staff-request/README.md
@@ -1,4 +1,4 @@
-# server-salon-staff-request
+# server-feature-salon-staff-request
 
 Purpose: Salon staff request domain feature library for the backend.
 
@@ -6,4 +6,4 @@ See overview: [libs/README.md](../../../README.md)
 
 ## Running unit tests
 
-Run `npx nx test server-salon-staff-request` to execute the unit tests.
+Run `npx nx test server-feature-salon-staff-request` to execute the unit tests.

--- a/libs/server/features/salon-staff-request/project.json
+++ b/libs/server/features/salon-staff-request/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "server-salon-staff-request",
+  "name": "server-feature-salon-staff-request",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "libs/server/features/salon-staff-request/src",

--- a/libs/server/features/salon/README.md
+++ b/libs/server/features/salon/README.md
@@ -1,4 +1,4 @@
-# server-salon
+# server-feature-salon
 
 Purpose: Salon domain feature library for the backend.
 
@@ -6,4 +6,4 @@ See overview: [libs/README.md](../../../README.md)
 
 ## Running unit tests
 
-Run `npx nx test server-salon` to execute the unit tests.
+Run `npx nx test server-feature-salon` to execute the unit tests.

--- a/libs/server/features/salon/project.json
+++ b/libs/server/features/salon/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "server-salon",
+  "name": "server-feature-salon",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "libs/server/features/salon/src",

--- a/libs/server/features/social/project.json
+++ b/libs/server/features/social/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "server-social",
+  "name": "server-feature-social",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "libs/server/features/social/src",

--- a/libs/server/features/theme/project.json
+++ b/libs/server/features/theme/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "server-theme",
+  "name": "server-feature-theme",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "libs/server/features/theme/src",

--- a/libs/server/features/user/project.json
+++ b/libs/server/features/user/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "server-user",
+  "name": "server-feature-user",
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "sourceRoot": "libs/server/features/user/src",

--- a/libs/server/features/user/src/index.ts
+++ b/libs/server/features/user/src/index.ts
@@ -1,4 +1,4 @@
-// Public API for server-user feature
+// Public API for server-feature-user
 export * from './lib/user.module';
 export * from './lib/dto/base-user.dto';
 export * from './lib/dto/create-user.dto';

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev:api": "nx serve api",
     "build": "nx run-many --target=build --all",
     "build:client-libs": "nx run-many -t build -p web-config,web-core-http,web-core-auth,web-core-testing,web-admin-auth,web-customer-auth,web-partner-auth,web-ui --skip-nx-cache",
-    "build:server-libs": "nx run-many -t build -p server-core,server-data-access,server-features,server-appointment,server-dashboard,server-portfolio,server-review,server-salon,server-salon-staff-request,server-social,server-theme,server-user --skip-nx-cache",
+    "build:server-libs": "nx run-many -t build -p server-core,server-data-access,server-features,server-feature-appointment,server-feature-dashboard,server-feature-portfolio,server-feature-review,server-feature-salon,server-feature-salon-staff-request,server-feature-social,server-feature-theme,server-feature-user --skip-nx-cache",
     "build:prod": "nx run-many --target=build --all --configuration=production",
     "build:affected": "nx affected:build",
     "build:web-admin": "nx build web-admin",


### PR DESCRIPTION
This PR standardizes Nx server feature project names to the server-feature-* convention and updates scripts/docs accordingly.\n\nChanges:\n- Rename Nx project names in libs/server/features/*/project.json (appointment, dashboard, portfolio, review, salon, salon-staff-request, social, theme, user)\n- Update package.json build:server-libs to use new names\n- Update feature READMEs titles and test commands to server-feature-*\n- Update comment in libs/server/features/user/src/index.ts\n\nVerification plan:\n- Lint: npx nx run-many -t lint --all\n- Tests: npx nx run-many -t test --all\n- Build: npx nx run-many -t build --all\n\nRisks/Mitigations:\n- Nx project name changes can affect task references; addressed by updating build script and scanning for old names.\n\nPlease review and approve.